### PR TITLE
Specify foreign key for subscriptions() relation

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -102,7 +102,7 @@ trait Billable
      */
     public function subscriptions()
     {
-        return $this->hasMany(Subscription::class)->orderBy('created_at', 'desc');
+        return $this->hasMany(Subscription::class, 'user_id')->orderBy('created_at', 'desc');
     }
 
     /**


### PR DESCRIPTION
Set the foreign key for the subscriptions() relation to "user_id", to mirror the user() relation in Subscription.php (which sets the local key to "user_id") and handle cases where the Stripe model isn't named "User".